### PR TITLE
handle lack of country code in detection result

### DIFF
--- a/addon/globalPlugins/translate/__init__.py
+++ b/addon/globalPlugins/translate/__init__.py
@@ -114,14 +114,17 @@ Stores the result into the cache so that the same translation does not asks deep
 				inlang = "zz"
 			if inlang == "zz":
 				translated = text	
-			elif _targetlang == "Auto" and inlang != _gpObject.language:
-				translatedRes = _translator.translate_text(prepared, target_lang=_gpObject.language, context=appcontext, split_sentences="nonewlines", preserve_formatting=True)
-				translated = translatedRes.text
-			elif inlang != _targetlang:
-				translatedRes = _translator.translate_text(prepared, target_lang=_targetlang, context=appcontext, split_sentences="nonewlines", preserve_formatting=True)
-				translated = translatedRes.text
 			else:
-				translated = text
+				targetlang = _gpObject.language if _targetlang == 'Auto' else _targetlang
+				# langdetect may not include a country code, we don't want to mismatch if that's the case
+				# E.G. EN vs. EN-US
+				dashpos = targetlang.find('-')
+				targetlang2 = targetlang if dashpos < 0 else targetlang[:dashpos]
+				if inlang != targetlang and inlang != targetlang2:
+					translatedRes = _translator.translate_text(prepared, target_lang=_targetlang, context=appcontext, split_sentences="nonewlines", preserve_formatting=True)
+					translated = translatedRes.text
+				else:
+					translated = text
 		else:
 			ui.message(_("You must place an API key in settings before translation."))
 


### PR DESCRIPTION
Guards against langdetect returning a language code alone without a country code when target language includes a country code. This allows it to E.G. skip sending text detected as EN off to be translated to En-US.  
This is done by creating a second version of the target language with the country code stripped, and comparing the detected language against both. Translation proceeds only if they both do not match. For languages that don't have a country code appended the second is equivalent to the first. This creates an extra comparison and construction.  
This could likely be improved by creating a global variable that stores potential variations of the language code as, say, a set, and a membership test. This global would then be updated upon any change in the target language setting, or changes to the language retrieved from NVDA.